### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC = g++
+CPPFLAGS = -std=c++11 -fPIC -O2 -fstack-protector-all
+CPPFLAGS += -Iinclude $(shell pkg-config --cflags nss)
+LDFLAGS = -shared
+
+TARGET = libmozpix.so
+
+SOURCES = $(shell echo lib/*.cpp)
+OBJECTS = $(SOURCES:.cpp=.o)
+
+.PHONY: all
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CPPFLAGS) $(OBJECTS) -o $@ $(LDFLAGS)
+
+clean:
+	@rm $(TARGET) $(OBJECTS)


### PR DESCRIPTION
Assumes `NSS` and `NSPR` headers exist on the system. Uses `pkg-config` to get header search paths.
